### PR TITLE
Add missing return value to SNP::read_bed

### DIFF
--- a/src/snp.cc
+++ b/src/snp.cc
@@ -249,7 +249,7 @@ SNP::read_bed(string s)
 
   fclose(bed_f);
   //fclose(maff);
-
+  return 0;
 }
 
 int


### PR DESCRIPTION
Could not use plink BED files without this, as a non-zero uninitialised int was returned, indicating error. BED format now works fine